### PR TITLE
Update howto-install-system-trusted-ca-android.md

### DIFF
--- a/docs/src/content/howto-install-system-trusted-ca-android.md
+++ b/docs/src/content/howto-install-system-trusted-ca-android.md
@@ -70,6 +70,18 @@ adb root
 ```bash
 adb shell "mount -o rw,remount /"
 ```
+- In case you receive a result like the following one:
+
+```bash
+adb shell "mount -o rw,remount /"
+'/dev/root' is read-only
+```
+
+- Execute the following command too, that should :
+
+```bash
+adb remount
+```
 
 - Push your certificate to the system certificate store and set file permissions
   


### PR DESCRIPTION
I found this issue trying to add it to a Xiami redmi Note8 with LineageOS 17.1

#### Description

Just a command to avoid an error that appears following the instructions.

#### Checklist

 - [ ] I have updated tests where applicable. - Not necessary
 - [ ] I have added an entry to the CHANGELOG. - Docuemntation change
